### PR TITLE
support main as default and can deploy to heroku after reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## v0.2.0
+
+Now assumes a default of main as the main branch.
+Works after heroku git has had its repo reset (e.g. after switching from master to main, see https://help.heroku.com/O0EXQZTA/how-do-i-switch-branches-from-master-to-main).

--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ Or install it yourself as:
 
 4) update heroku_targets.yml with your staging and production targets. 
   My set up for this is to have staging deploy the local version, but production 
-  deploy the origin/master.
+  deploy the origin/main.
 
+   NB: master vs main
+   heroku-tool (as of 0.2.0) assumes the new current standard of main as the main branch, but if you're on the older standard of "master" then adjust your deploy refs to origin/master and the heroku_target_ref: in defaults to be ref/heads/master
+   
       > TODO: more detail
  
 5) You may want to set up a smoke test that your heroku targets are valid

--- a/lib/heroku_tool/heroku_targets.rb
+++ b/lib/heroku_tool/heroku_targets.rb
@@ -95,6 +95,10 @@ module HerokuTool
         @values[:repository] || raise(required_value(:repository))
       end
 
+      def heroku_target_ref
+        @values[:heroku_target_ref] || "refs/heads/main"
+      end
+
       def to_s
         display_name
       end

--- a/lib/heroku_tool/tasks/heroku.thor
+++ b/lib/heroku_tool/tasks/heroku.thor
@@ -198,7 +198,7 @@ class Heroku < Thor
     message = deploy_message(target, deploy_ref_description)
     Configuration.before_deploying(self, target, deploy_ref_description)
     set_message(target_name, message)
-    puts_and_system "git push -f #{target.git_remote} #{deploy_ref}^{}:master"
+    puts_and_system "git push -f #{target.git_remote} #{deploy_ref}^{}:#{target.heroku_target_ref}"
 
     maintenance_on(target) if maintenance
     if options[:migrate]

--- a/lib/heroku_tool/version.rb
+++ b/lib/heroku_tool/version.rb
@@ -1,3 +1,3 @@
 module HerokuTool
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/heroku_targets_spec.rb
+++ b/spec/heroku_targets_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe HerokuTool::HerokuTargets do
   production:
     heroku_app : my-production-heroku_app
     git_remote : heroku_production
-    deploy_ref : origin/master
+    deploy_ref : origin/main
   staging:
     heroku_app : my-staging-heroku_app
     git_remote : heroku_production
-    deploy_ref : origin/master
+    deploy_ref : origin/main
     display_name : My Lovely Staging heroku_app
     staging : true
     db_color : NAVY
@@ -72,7 +72,7 @@ RSpec.describe HerokuTool::HerokuTargets do
     valid_file_with_defaults = <<-VALID
     _defaults:
       repository : https://mygit.hub.com/some/where
-      deploy_ref : origin/master
+      deploy_ref : origin/main
     production:
       heroku_app : my-production-heroku_app
       git_remote : heroku_production
@@ -85,7 +85,7 @@ RSpec.describe HerokuTool::HerokuTargets do
     let(:valid_ht) { HerokuTool::HerokuTargets.from_string(valid_file_with_defaults) }
 
     it "can use defaults for deploy_ref" do
-      expect(valid_ht.targets["production"].deploy_ref).to eq("origin/master")
+      expect(valid_ht.targets["production"].deploy_ref).to eq("origin/main")
     end
     it "can override defaults for deploy_ref" do
       expect(valid_ht.targets["staging"].deploy_ref).to eq("HEAD")
@@ -93,6 +93,40 @@ RSpec.describe HerokuTool::HerokuTargets do
     it "should use defaults for repository" do
       [valid_ht.targets["staging"], valid_ht.targets["production"]].each do |target|
         expect(target.repository).to eq("https://mygit.hub.com/some/where")
+      end
+    end
+  end
+
+  describe "heroku_target_ref" do
+    context "out of the box" do
+      it "uses refs/heads/main" do
+        expect(valid_ht.targets["staging"].heroku_target_ref).to eq("refs/heads/main")
+        expect(valid_ht.targets["production"].heroku_target_ref).to eq("refs/heads/main")
+      end
+    end
+    context "can be explicitly set" do
+      valid_file_with_defaults = <<-VALID
+      _defaults:
+        repository : https://mygit.hub.com/some/where
+        deploy_ref : origin/main
+        heroku_target_ref : refs/heads/master
+      production:
+        heroku_app : my-production-heroku_app
+        git_remote : heroku_production
+      staging:
+        heroku_app : my-staging-heroku_app
+        git_remote : heroku_staging
+        deploy_ref : HEAD
+        heroku_target_ref: refs/heads/main
+      VALID
+
+      let(:valid_ht) { HerokuTool::HerokuTargets.from_string(valid_file_with_defaults) }
+
+      it "can set a new default" do
+        expect(valid_ht.targets["production"].heroku_target_ref).to eq("refs/heads/master")
+      end
+      it "can override" do
+        expect(valid_ht.targets["staging"].heroku_target_ref).to eq("refs/heads/main")
       end
     end
   end

--- a/spec/heroku_thor_spec.rb
+++ b/spec/heroku_thor_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Heroku thor" do
       production:
         heroku_app : my-heroku-app
         git_remote : heroku-production
-        deploy_ref : origin/master
+        deploy_ref : origin/main
         display_name : my.heroku.com
       staging:
         heroku_app : my-heroku-staging-app

--- a/templates/heroku_targets.yml
+++ b/templates/heroku_targets.yml
@@ -1,10 +1,12 @@
 # find `database_url` by running `heroku pg:info --app=APP_NAME`
 _defaults:
   repository: https://github.com/red56/heroku_tool
+  # what you are deploying to -- this should either be refs/head/main (the default) or refs/head/master
+  heroku_target_ref: refs/heads/main
 production:
   heroku_app : some-heroku-production
   git_remote : heroku-production
-  deploy_ref : origin/master
+  deploy_ref : origin/main
   display_name : production (heroku_tool)
 demo:
   heroku_app : some-heroku-demo


### PR DESCRIPTION
needs to deploy to ref/heads/main (or ref/heads/master) when the
remote repository has been reset.