### PR TITLE
allow for migrate_in_release_phase: true

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ Or install it yourself as:
 
 ### Deploy 
 
-Deploy the latest with db migrate during maintenance
+Deploy the latest with db migrate *(but see below) during maintenance
 
     thor heroku:deploy staging
 
-or without maintenance
+or without maintenance*
 
     thor heroku:deploy staging --no-maintenance
 
-or without migrating
+or without migrating*
 
     thor heroku:deploy staging --no-migrate
     
@@ -72,6 +72,14 @@ or a specific tag/branch
 
     thor heroku:deploy staging hotfix-branch
 
+*Note on db:migrate:
+
+It is very possible to run migrations as part of the heroku release phase:
+* https://mentalized.net/journal/2017/04/22/run-rails-migrations-on-heroku-deploy/
+* https://devcenter.heroku.com/articles/release-phase#design-considerations
+
+In this case you should set `migrate_in_release_phase: true` in your defaults (see templates/heroku_targets.yml)
+and you won't run migrate as a separate step.
 
 ### Sync
 

--- a/lib/heroku_tool/heroku_targets.rb
+++ b/lib/heroku_tool/heroku_targets.rb
@@ -99,6 +99,10 @@ module HerokuTool
         @values[:heroku_target_ref] || "refs/heads/main"
       end
 
+      def migrate_in_release_phase
+        @values[:migrate_in_release_phase]
+      end
+
       def to_s
         display_name
       end

--- a/spec/heroku_targets_spec.rb
+++ b/spec/heroku_targets_spec.rb
@@ -67,12 +67,18 @@ RSpec.describe HerokuTool::HerokuTargets do
         expect { target.repository }.to raise_error(/repository/)
       end
     end
+    it "should infer migrate_in_release_phase" do
+      [valid_ht.targets["staging"], valid_ht.targets["production"]].each do |target|
+        expect( target.migrate_in_release_phase ).to be_falsey
+      end
+    end
   end
   describe "with defaults" do
     valid_file_with_defaults = <<-VALID
     _defaults:
       repository : https://mygit.hub.com/some/where
       deploy_ref : origin/main
+      migrate_in_release_phase : true
     production:
       heroku_app : my-production-heroku_app
       git_remote : heroku_production
@@ -93,6 +99,11 @@ RSpec.describe HerokuTool::HerokuTargets do
     it "should use defaults for repository" do
       [valid_ht.targets["staging"], valid_ht.targets["production"]].each do |target|
         expect(target.repository).to eq("https://mygit.hub.com/some/where")
+      end
+    end
+    it "should use defaults for migrate_in_release_phase" do
+      [valid_ht.targets["staging"], valid_ht.targets["production"]].each do |target|
+        expect(target.migrate_in_release_phase).to be_truthy
       end
     end
   end

--- a/templates/heroku_targets.yml
+++ b/templates/heroku_targets.yml
@@ -3,6 +3,10 @@ _defaults:
   repository: https://github.com/red56/heroku_tool
   # what you are deploying to -- this should either be refs/head/main (the default) or refs/head/master
   heroku_target_ref: refs/heads/main
+  # set to true if you are doing migrate as part of the heroku release phase, otherwise leave as false, or delete
+  #  https://mentalized.net/journal/2017/04/22/run-rails-migrations-on-heroku-deploy/
+  #  https://devcenter.heroku.com/articles/release-phase
+  migrate_in_release_phase: false
 production:
   heroku_app : some-heroku-production
   git_remote : heroku-production


### PR DESCRIPTION
It is very possible to run migrations as part of the heroku release phase:
* https://mentalized.net/journal/2017/04/22/run-rails-migrations-on-heroku-deploy/
* https://devcenter.heroku.com/articles/release-phase#design-considerations

In this case you should set `migrate_in_release_phase: true` in your defaults (see templates/heroku_targets.yml)